### PR TITLE
Change default node version to 10

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-nodejs_version: 8
+nodejs_version: 10
 
 nodejs_setup_script: "setup_{{ nodejs_version }}.x"
 


### PR DESCRIPTION
Node 8 is long deprecated. Node 10 (LTS) is in maintenance.